### PR TITLE
Add visual markers for the start of each year in the lifetime calendar

### DIFF
--- a/frontend/src/components/LifetimeCalendar.vue
+++ b/frontend/src/components/LifetimeCalendar.vue
@@ -91,6 +91,11 @@ const getWeekClass = (week) => {
   if (week.note) {
     classes.push('has-note')
   }
+
+  // Mark the first week of each calendar year
+  if (week.week_of_year === 1) {
+    classes.push('year-start')
+  }
   
   return classes.join(' ')
 }
@@ -148,6 +153,10 @@ onMounted(() => {
         <div class="legend-item">
           <div class="legend-box has-note"></div>
           <span>Has Note</span>
+        </div>
+        <div class="legend-item">
+          <div class="legend-box year-start"></div>
+          <span>New Year</span>
         </div>
       </div>
 
@@ -313,6 +322,13 @@ onMounted(() => {
   box-shadow: inset 0 0 0 2px #8b5cf6;
 }
 
+/* Legend sample for year start */
+.legend-box.year-start {
+  background: white;
+  border-color: #e5e7eb;
+  box-shadow: inset 3px 0 0 #3b82f6; /* blue tick on the left */
+}
+
 .calendar-grid {
   background: white;
   border-radius: 8px;
@@ -353,6 +369,12 @@ onMounted(() => {
   cursor: pointer;
   transition: all 0.2s ease;
   background: white;
+  position: relative; /* for year-start marker */
+}
+
+/* Visual marker for the first week of each year */
+.week-box.year-start {
+  box-shadow: inset 3px 0 0 #3b82f6; /* blue left tick */
 }
 
 .week-box:hover {


### PR DESCRIPTION
This PR adds a clear visual indicator for the start of each calendar year in the weeks grid:

- Adds `year-start` class to weeks where `week.week_of_year === 1`
- Styles these weeks with a blue left tick using `box-shadow`
- Updates the legend with a "New Year" sample

Why:
- Makes it easier to orient within the grid and see yearly boundaries at a glance.

Notes:
- Uses `week.week_of_year` from the API; if your API uses a different field name, update `getWeekClass` accordingly.
- Non-invasive change—no layout shifts or new dependencies.